### PR TITLE
Fix --no-git-checks

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -37,4 +37,7 @@ jobs:
       - name: "Update version in package.json"
         run: "pnpm version ${VERSION} --no-git-tag-version"
       - name: "Publish"
-        run: "pnpm publish --provenance --access public"
+        # --provenance identifies the build as having come from github actions
+        # --access public makes it publicly visible
+        # --no-git-checks tells pnpm not to worry about the fact that we've changed the version
+        run: "pnpm publish --provenance --access public --no-git-checks"


### PR DESCRIPTION
## Description
https://github.com/authzed/spicedb-parser-js/actions/runs/19941560321

We had a failure on the first release :facepalm: 

## Changes
* Add `--no-git-checks` and added some comments
## Testing
Review.