### PR TITLE
ci: ensure most recent version of npm is available

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -24,6 +24,10 @@ jobs:
         with:
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
+      # Ensure npm 11.5.1 or later is installed;
+      # this is required for publishing using OIDC authn
+      - name: "Update npm"
+        run: "npm install -g npm@"
       - name: "Install dependencies"
         run: "pnpm install"
       # Set the version in package.json to match the tag


### PR DESCRIPTION
## Description
This should fix this failure: https://github.com/authzed/spicedb-parser-js/actions/runs/19941813817/job/57181232199

My assumption is that we're not on a recent enough version of `npm`, which means that it's not using OIDC auth.

## Changes
Add step to install most recent version of npm

## Testing
Review.