### PR TITLE
ci: go back to github runner

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   publish:
     name: Publish to NPM
-    runs-on: "depot-ubuntu-24.04-small"
+    runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v6
       - uses: "pnpm/action-setup@v4"


### PR DESCRIPTION
## Description
Provenance is only available when you're on official github-hosted runners, so let's use them.

https://github.com/authzed/spicedb-parser-js/actions/runs/19943944776/job/57188612310