### PR TITLE
Add support for self expression syntax

### DIFF
--- a/src/dsl.test.ts
+++ b/src/dsl.test.ts
@@ -461,6 +461,85 @@ definition user {}
       expect(rightExpr.relationName).toEqual("d");
     });
 
+    it("parses definition with a self permission", () => {
+      const schema = `definition foo {
+          relation viewer: bar
+          permission view = viewer + self
+        }`;
+      const parsed = parseSchema(schema);
+
+      expect(parsed?.definitions.length).toEqual(1);
+
+      const definition = parsed?.definitions[0];
+      assert(definition);
+      assert(definition.kind === "objectDef");
+      expect(definition.permissions).toHaveLength(1);
+
+      const permission = definition.permissions[0];
+      assert(permission);
+      expect(permission.name).toEqual("view");
+
+      const binExpr = permission.expr;
+      assert(binExpr.kind === "binary");
+      expect(binExpr.operator).toEqual("union");
+
+      const leftExpr = binExpr.left;
+      assert(leftExpr.kind === "relationref");
+      expect(leftExpr.relationName).toEqual("viewer");
+
+      const rightExpr = binExpr.right;
+      assert(rightExpr.kind === "self");
+    });
+
+    it("parses definition with a standalone self permission", () => {
+      const schema = `definition foo {
+          permission view = self
+        }`;
+      const parsed = parseSchema(schema);
+
+      expect(parsed?.definitions.length).toEqual(1);
+
+      const definition = parsed?.definitions[0];
+      assert(definition);
+      assert(definition.kind === "objectDef");
+      expect(definition.permissions).toHaveLength(1);
+
+      const permission = definition.permissions[0];
+      assert(permission);
+      expect(permission.name).toEqual("view");
+
+      const selfExpr = permission.expr;
+      assert(selfExpr.kind === "self");
+    });
+
+    it("parses definition with self in a complex expression", () => {
+      const schema = `definition foo {
+          permission first = ((a - b) + self) & d;
+        }`;
+      const parsed = parseSchema(schema);
+
+      expect(parsed?.definitions.length).toEqual(1);
+
+      const definition = parsed?.definitions[0];
+      assert(definition);
+      assert(definition.kind === "objectDef");
+      expect(definition.permissions).toHaveLength(1);
+
+      const permission = definition.permissions[0];
+      assert(permission);
+
+      const binExpr = permission.expr;
+      assert(binExpr.kind === "binary");
+      expect(binExpr.operator).toEqual("intersection");
+
+      const leftExpr = binExpr.left;
+      assert(leftExpr.kind === "binary");
+      expect(leftExpr.operator).toEqual("union");
+
+      const rightLeftExpr = leftExpr.right;
+      assert(rightLeftExpr.kind === "self");
+    });
+
     it("parses definition with multiple permissions", () => {
       const schema = `definition foo {
           permission first = firstrel

--- a/src/dsl.ts
+++ b/src/dsl.ts
@@ -130,6 +130,11 @@ export function flatMapExpression<T>(
       return nilResult ? [nilResult] : [];
     }
 
+    case "self": {
+      const selfResult = walker(expr);
+      return selfResult ? [selfResult] : [];
+    }
+
     case "relationref": {
       const result = walker(expr);
       return result ? [result] : [];
@@ -280,7 +285,8 @@ export type ParsedExpression =
   | ParsedRelationRefExpression
   | ParsedArrowExpression
   | ParsedNamedArrowExpression
-  | ParsedNilExpression;
+  | ParsedNilExpression
+  | ParsedSelfExpression;
 
 export type ParsedArrowExpression = {
   kind: "arrow";
@@ -306,6 +312,11 @@ export type ParsedRelationRefExpression = {
 export type ParsedNilExpression = {
   kind: "nil";
   isNil: true;
+  range: TextRange;
+};
+
+export type ParsedSelfExpression = {
+  kind: "self";
   range: TextRange;
 };
 
@@ -582,6 +593,20 @@ const nilExpr: Parser<ParsedNilExpression> = lazy(() => {
   );
 });
 
+const selfExpr: Parser<ParsedSelfExpression> = lazy(() => {
+  return seqMap(
+    index,
+    string("self"),
+    index,
+    function (startIndex, _data, endIndex) {
+      return {
+        kind: "self",
+        range: { startIndex: startIndex, endIndex: endIndex },
+      };
+    },
+  );
+});
+
 const parensExpr = lazy(() =>
   string("(")
     .then(expr)
@@ -589,6 +614,7 @@ const parensExpr = lazy(() =>
     .or(arrowExpr)
     .or(namedArrowExpr)
     .or(nilExpr)
+    .or(selfExpr)
     .or(relationReference),
 );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export type {
   ParsedBinaryExpression,
   ParsedExpression,
   ParsedRelationRefExpression,
+  ParsedSelfExpression,
   TypeRef,
 } from "./dsl";
 export { ResolvedDefinition, Resolver } from "./resolution";


### PR DESCRIPTION
## Description

Adds support for parsing `self` in permission expressions, following the same pattern as `nil`. This allows schemas like `permission view = viewer + self` to be parsed correctly.

Tested locally against the playground, `self` is no longer highlighted in red.

<img width="1912" height="1241" alt="Screenshot 2026-03-25 at 6 48 21 PM" src="https://github.com/user-attachments/assets/f577c280-1b1b-4cad-ae94-9a540cd4bf3b" />


Fixes #14